### PR TITLE
fix boost::locale min/max

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,10 @@ endif()
 aux_source_directory(src charcode_src)
 
 add_library(rime-charcode-objs OBJECT ${charcode_src})
+# Work around min/max in boost::locale
+if(WIN32)
+  target_compile_definitions(rime-charcode-objs PRIVATE NOMINMAX)
+endif()
 if(BUILD_SHARED_LIBS)
   set_target_properties(rime-charcode-objs
     PROPERTIES


### PR DESCRIPTION
A classic windows minmax problem.
Before: [release CI](https://github.com/rime/librime/actions/runs/6064923382/job/16453870252) for https://github.com/rime/librime/commit/9e9141864fc5a63e8738d5f994cea7c976f080af
![Screenshot from 2023-09-03 23-14-04](https://github.com/rime/librime-charcode/assets/26783539/1e027827-2c68-463a-9fec-ed4c97158d15)

After: [release CI](https://github.com/rime/librime/actions/runs/6068513313/job/16461568111) for https://github.com/rime/librime/commit/024651cfbf567f1a24f1394fbafbca86e131a70c
![Screenshot from 2023-09-03 23-34-09](https://github.com/rime/librime-charcode/assets/26783539/b3063cf3-39cb-4b2e-bcbe-e4b032524a58)