### PR TITLE
build: not depends on boost asio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,11 @@ if(Boost_FOUND)
   link_directories(${Boost_LIBRARY_DIRS})
 endif()
 
+if(WIN32)
+  set(WS2_LIBRARY ws2_32)
+endif(WIN32)
+
+
 aux_source_directory(src charcode_src)
 
 add_library(rime-charcode-objs OBJECT ${charcode_src})
@@ -38,6 +43,7 @@ target_link_libraries(rime-charcode-deps INTERFACE
   ${Boost_LOCALE_LIBRARIES}
   ${ICONV_LIBRARIES}
   ${ICU_LIBRARIES}
+  ${WS2_LIBRARY}
 )
 
 set(charcode_library rime-charcode)

--- a/src/codepoint_translator.cc
+++ b/src/codepoint_translator.cc
@@ -5,7 +5,9 @@
 // 2016-09-08 osfans <waxaca@163.com>
 //
 
-#include <boost/asio.hpp>
+#ifdef _WIN32
+#include <WinSock2.h>
+#endif
 #include <boost/algorithm/string.hpp>
 #include <boost/locale.hpp>
 


### PR DESCRIPTION
Since there are just two tiny functions are used, and system library can meet its requirement, let us drop boot asio here.